### PR TITLE
[종혁] 문제풀이 완료 (신입사원교육 및 석유시추)

### DIFF
--- a/프로그래머스/PCCP/신입사원교육/JH.js
+++ b/프로그래머스/PCCP/신입사원교육/JH.js
@@ -1,0 +1,55 @@
+function solution(ability, number) {
+  class Heap {
+    constructor() {
+      this.heap = []
+    }
+    push(val) {
+      this.heap.push(val)
+      let curIdx = this.heap.length - 1
+      let parentIdx = Math.floor((curIdx - 1) / 2)
+      while (this.heap[parentIdx] && this.heap[parentIdx] > this.heap[curIdx]) {
+        ;[this.heap[parentIdx], this.heap[curIdx]] = [this.heap[curIdx], this.heap[parentIdx]]
+        curIdx = parentIdx
+        parentIdx = Math.floor((curIdx - 1) / 2)
+      }
+    }
+    shift() {
+      this.heap[0] = this.heap.pop()
+      let idx = 0
+      let leftIdx = idx * 2 + 1
+      let rightIdx = idx * 2 + 2
+      while (
+        (this.heap[leftIdx] && this.heap[leftIdx] < this.heap[idx]) ||
+        (this.heap[rightIdx] && this.heap[rightIdx] < this.heap[idx])
+      ) {
+        let targetIdx = leftIdx // 왼쪽 자식 노드가 더 작다고 가정
+        if (this.heap[leftIdx] && this.heap[leftIdx] < this.heap[targetIdx]) {
+          targetIdx = leftIdx
+        } else if (
+          this.heap[rightIdx] &&
+          this.heap[rightIdx] <= this.heap[targetIdx] // 오른쪽 자식 노드가 더 작다면
+        ) {
+          targetIdx = rightIdx // 오른쪽 자식 노드의 index로 변경
+        }
+        ;[this.heap[idx], this.heap[targetIdx]] = [this.heap[targetIdx], this.heap[idx]]
+        idx = targetIdx
+        leftIdx = idx * 2 + 1
+        rightIdx = idx * 2 + 2
+      }
+    }
+  }
+  const minHeap = new Heap()
+  for (const n of ability) {
+    minHeap.push(n)
+  }
+
+  for (let i = 0; i < number; i++) {
+    const sum = minHeap.heap[0] + minHeap.heap[1]
+    minHeap.shift()
+    minHeap.shift()
+    minHeap.push(sum)
+    minHeap.push(sum)
+  }
+  const a = minHeap.heap.reduce((v, i) => v + i)
+  return a
+}

--- a/프로그래머스/PCCP/체육대회/JH.js
+++ b/프로그래머스/PCCP/체육대회/JH.js
@@ -1,0 +1,33 @@
+function solution(ability) {
+  const types = Array(ability[0].length + 1).fill(0)
+  let result = 0
+  const typesArray = []
+  const 종목경우의수 = (typesArr, studentsArr) => {
+    if (typesArr.length >= studentsArr.length) {
+      let sum = 0
+      for (let i = 0; i < typesArr.length; i++) {
+        sum += ability[studentsArr[i] - 1][typesArr[i] - 1]
+      }
+      result = Math.max(result, sum)
+      return
+    }
+    for (let i = 1; i < types.length; i++) {
+      if (!types[i]) {
+        types[i] = 1
+        종목경우의수([...typesArr, i], studentsArr)
+        types[i] = 0
+      }
+    }
+  }
+  const 학생경우의수 = (arr, idx) => {
+    if (arr.length >= types.length - 1) {
+      종목경우의수([], arr)
+      return
+    }
+    for (let i = idx + 1; i <= ability.length; i++) {
+      학생경우의수([...arr, i], i)
+    }
+  }
+  학생경우의수([], 0)
+  return result
+}


### PR DESCRIPTION
## 🧩 구현
- 체육대회
  - dfs 방식을 통해 주어져 있는 종목의 수 만큼 학생을 뽑고 + 학생들이 각각 종목 한개씩을 담당했을 때의 합산값을 구해야 함
  - 학생을 뽑는 dfs에서는 중복을 허용하지 않음
- 신입사원 교육
   - 일반적인 방법으로는 시간복잡도가 10^8까지 나올 수 있음
   - 제일 작은 값을 가진 2개의 합을 구한 뒤, 현재 정렬을 깨트리지 않으면서 변한 2개의 원소를 제 위치에 넣을 수 있어야 함
   - 최소 힙 방식이 가장 유리
## 🎼 블로킹과 개선방안
- dfs가 오랜만이어서, 중복에 관한 생각을 하는 데에 좀 오래 걸렸던 것 같다
- 신입 사원 교육의 경우 이분탐색으로 먼저 접근했었는데, 한 개 빼고 통과해서 이 방법이 옳다고 생각하고 시간을 많이 잡아먹었다. 

## 🔗 레퍼런스
