### PR TITLE
[재웅] 문제 풀이 완료 (1/31, 카페확장)

### DIFF
--- a/프로그래머스/PCCP/카페확장/JW.js
+++ b/프로그래머스/PCCP/카페확장/JW.js
@@ -3,7 +3,7 @@ function solution(menu, order, k) {
   let maxResult = 0;
 
   const mappedOrder = order.map((o, i) => {
-    coffeeMadeTime += menu[o];
+    coffeeMadeTime = Math.max(coffeeMadeTime, k * i) + menu[o];
     return [k * i, coffeeMadeTime];
   });
 
@@ -25,16 +25,9 @@ function solution(menu, order, k) {
         stack.push(m);
       }
     });
+
     maxResult = Math.max(maxResult, stack.length);
   });
 
   return maxResult;
-
-  //     1차원으로 spread된 mappedOrder을 순회하며, 해당 시간내 들어올 수 있는 손님을 전부 넣음
-  //     하나씩 빼면서 [0] <= time <= [1]이고,
-  //     queue의 마지막 원소의 퇴장 시간과 현재 시간, 새로 들어오는 원소의 입장 시간이 같을 경우
-  //     queue의 마지막 손님을 내보냄
-  //     해당 시간내에서 mappedOrder을 전부 순회하였을 때 qeueue의 길이를 반환
 }
-
-// 테스트케이스 4, 5, 7, 8, 10 실패

--- a/프로그래머스/PCCP/카페확장/JW.js
+++ b/프로그래머스/PCCP/카페확장/JW.js
@@ -1,0 +1,40 @@
+function solution(menu, order, k) {
+  let coffeeMadeTime = 0;
+  let maxResult = 0;
+
+  const mappedOrder = order.map((o, i) => {
+    coffeeMadeTime += menu[o];
+    return [k * i, coffeeMadeTime];
+  });
+
+  const flattedOrder = mappedOrder.flat();
+
+  flattedOrder.forEach((f) => {
+    const stack = [];
+
+    mappedOrder.forEach((m) => {
+      const [inTime, outTime] = m;
+      if (
+        stack.length > 0 &&
+        stack[stack.length - 1][1] === f &&
+        inTime === f
+      ) {
+        stack.pop();
+      }
+      if (inTime <= f && outTime >= f) {
+        stack.push(m);
+      }
+    });
+    maxResult = Math.max(maxResult, stack.length);
+  });
+
+  return maxResult;
+
+  //     1차원으로 spread된 mappedOrder을 순회하며, 해당 시간내 들어올 수 있는 손님을 전부 넣음
+  //     하나씩 빼면서 [0] <= time <= [1]이고,
+  //     queue의 마지막 원소의 퇴장 시간과 현재 시간, 새로 들어오는 원소의 입장 시간이 같을 경우
+  //     queue의 마지막 손님을 내보냄
+  //     해당 시간내에서 mappedOrder을 전부 순회하였을 때 qeueue의 길이를 반환
+}
+
+// 테스트케이스 4, 5, 7, 8, 10 실패


### PR DESCRIPTION
## 🧩 구현
<!-- 문제에 어떻게 접근했는지, 어떤 알고리즘과 자료구조를 적용하여 문제를 해결했는지 -->

1. mappedOrder은 각 손님의 입장 시간과 퇴장 시간을 담고 있는 2차원 배열로, 아래와 같은 형태를 띄고 있음
`[ [ 0, 12 ], [ 10, 42 ], [ 20, 47 ], [ 30, 59 ] ]`
2. 1차원으로 spread된 mappedOrder을 순회하며, 해당 시간내 들어올 수 있는 손님을 전부 추가
3. 각 손님의 inTime <= time <= outTime 조건을 만족할 때 stack에 들어올 수 있음
4. 또한 stack의 마지막 원소의 퇴장 시간과 현재 시간, 새로 들어오는 원소의 입장 시간이 같을 경우 stack의 마지막 손님을 내보냄
6. 해당 시간내에서 mappedOrder을 전부 순회하였을 때 stack의 길이를 반환


## 🎼 블로킹과 개선방안
<!-- 문제를 풀면서 고전했던 부분과, 이를 어떻게 해결하였는지 -->
<!-- 코드의 성능과 복잡도를 개선시킬 수 있는 방법, 알고리즘이 있는지 -->
1. 일부 테스트케이스를 통과하지 못하며, 대부분 2000ms의 연산 시간이 소요되어 성능이 좋지 않음
2. 기존에는 이전 주문의 제조 시간을 누적하여 계산하고 있었고, 이전 주문 완성 전 새로 들어오는 주문을 고려하지 않았어서 이를 반영
3. 따라서 현재 주문이 시작되는 시간과 이전 주문이 완성되는 시간 중 더 늦은 시간을 기준으로 계산하도록 함